### PR TITLE
Use req.originalUrl instead of req.path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{
-            hashFiles('**/package-lock.json') }},
+            hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.20.0
-          registry-url: 'https://npm.pkg.github.com'
-
-      #- name: 🔍 Get npm cache directory path
-      # id: yarn-cache-dir-path
-      # run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: 🧶 Get NPM cache
         uses: actions/cache@v3
-        id: cache-npm # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: cache-npm
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: 🏗️ Build @last9/openapm
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: ⬢ Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.20.0
+          registry-url: 'https://npm.pkg.github.com'
+
+      #- name: 🔍 Get npm cache directory path
+      # id: yarn-cache-dir-path
+      # run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: 🧶 Get NPM cache
+        uses: actions/cache@v3
+        id: cache-npm # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{
+            hashFiles('**/package-lock.json') }},
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: 📦 Install dependencies
+        run: npm install --frozen-lockfile
+
+      - name: 🧪 Test
+        run: npm run test
+
+      - name: 👷 Build
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Release
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: 🛎 Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.1.1-beta.1",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.1.1",
+  "version": "0.1.1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.1.1",
+      "version": "0.1.1-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "openapm",
-  "version": "0.1.0",
+  "name": "@last9/openapm",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "openapm",
-      "version": "0.1.0",
+      "name": "@last9/openapm",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.1.1",
+  "version": "0.1.1-beta.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "scripts": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,15 @@ export const getHostIpAddress = () => {
   return null;
 };
 
+/**
+ *
+ * @param pathname
+ * @param extraMasks Array of regexp for when matched should replace that part of the pathname
+ * @param replacement Defaults to :id, replacement string
+ * @returns The parsed pathname. Example 👇
+ *
+ * @example /users/1/settings -> /users/:id/settings
+ */
 export const getParsedPathname = (
   pathname: string,
   extraMasks?: Array<RegExp>,
@@ -44,6 +53,12 @@ export const getParsedPathname = (
 };
 
 export const getSanitizedPath = (pathname: string) => {
+  /**
+   * Regex will remove any hashes or the search param in the pathname
+   * @example /foo?bar=zar -> /foo
+   * @example /foo#intro  -> /foo
+   * @example /foo?lorem=ipsum&bar=zar -> /foo
+   */
   const sanitizedPath = pathname.replace(
     /(\/[^?#]+)(?:\?[^#]*)?(?:#.*)?$/,
     '$1'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,15 @@
-import * as fs from "fs";
-import * as path from "path";
-import * as os from "os";
-import UrlValueParser from "url-value-parser";
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import UrlValueParser from 'url-value-parser';
 
 export const getPackageJson = () => {
-  const packageJsonPath = path.join(process.cwd(), "package.json");
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
   try {
-    const packageJson = fs.readFileSync(packageJsonPath, "utf-8");
+    const packageJson = fs.readFileSync(packageJsonPath, 'utf-8');
     return JSON.parse(packageJson);
   } catch (error) {
-    console.error("Error parsing package.json");
+    console.error('Error parsing package.json');
     return null;
   }
 };
@@ -20,10 +20,10 @@ export const getHostIpAddress = () => {
   // Iterate over network interfaces to find a non-internal IPv4 address
   for (const interfaceName in networkInterfaces) {
     const interfaces = networkInterfaces[interfaceName];
-    if (typeof interfaces !== "undefined") {
+    if (typeof interfaces !== 'undefined') {
       for (const iface of interfaces) {
         // Skip internal and non-IPv4 addresses
-        if (!iface.internal && iface.family === "IPv4") {
+        if (!iface.internal && iface.family === 'IPv4') {
           return iface.address;
         }
       }
@@ -37,8 +37,16 @@ export const getHostIpAddress = () => {
 export const getParsedPathname = (
   pathname: string,
   extraMasks?: Array<RegExp>,
-  replacement: string = ":id"
+  replacement: string = ':id'
 ) => {
   const parser = new UrlValueParser({ extraMasks });
   return parser.replacePathValues(pathname, replacement);
+};
+
+export const getSanitizedPath = (pathname: string) => {
+  const sanitizedPath = pathname.replace(
+    /(\/[^?#]+)(?:\?[^#]*)?(?:#.*)?$/,
+    '$1'
+  );
+  return sanitizedPath;
 };

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,11 +1,21 @@
 import request from 'supertest';
-import { Express } from 'express';
+import express from 'express';
+import type { Express } from 'express';
 
 export const addRoutes = (app: Express) => {
+  const router = express.Router();
+
+  router.get('/:id', (req, res) => {
+    const { id } = req.params;
+    console.log(id);
+    res.status(200).send(id);
+  });
+  app.use('/api/router/', router);
   app.get('/api/:id', (req, res) => {
     const { id } = req.params;
     res.status(200).send(id);
   });
+
   return app;
 };
 
@@ -16,16 +26,14 @@ function getRandomId() {
 }
 
 export const sendTestRequests = async (app: Express, num: number) => {
-  const out: Array<Record<string, number>> = [];
   for (let index = 0; index < num; index++) {
     const id = getRandomId();
     try {
       const res = await request(app).get(`/api/${id}`);
-      out.push({ [id]: res.status });
     } catch (err) {
       throw new Error(err);
     }
   }
-
-  return out;
+  const id = getRandomId();
+  await request(app).get(`/api/router/${id}`);
 };


### PR DESCRIPTION
Using req.originalUrl instead of req.path because in some cases the req.path is coming out to be only `/`